### PR TITLE
Fix GitHub spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Dynamic Profile Page On Github
+# Dynamic Profile Page On GitHub
 
 A GitHub action to push updates to your special profile repo.
 


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`.